### PR TITLE
eslint 사용하지 않는 import 문 제거

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,8 @@ module.exports = {
     "jsx-a11y",
     // Prettier 플러그인
     "prettier",
+    // Unused imports 플러그인
+    "unused-imports",
   ],
   rules: {
     // Prettier 규칙을 ESLint 오류로 설정
@@ -76,5 +78,17 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     // any 타입 사용을 허용
     "@typescript-eslint/no-explicit-any": "off",
+    // 사용되지 않는 import 구문을 제거
+    "unused-imports/no-unused-imports": "error",
+    // 사용되지 않는 변수와 함수는 경고로 설정
+    "no-unused-vars": [
+      "warn",
+      {
+        vars: "all",
+        varsIgnorePattern: "^_",
+        args: "after-used",
+        argsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-config-next": "14.2.9",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-unused-imports": "^4.1.3",
         "postcss": "^8",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
@@ -2039,6 +2040,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.3.tgz",
+      "integrity": "sha512-lqrNZIZjFMUr7P06eoKtQLwyVRibvG7N+LtfKtObYGizAAGrcqLkc3tDx+iAik2z7q0j/XI3ihjupIqxhFabFA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-next": "14.2.9",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-unused-imports": "^4.1.3",
     "postcss": "^8",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
사용하지 않은 import문을 제거하는 코드를 추가했습니다.

``` js
// 사용되지 않는 import 구문을 제거
"unused-imports/no-unused-imports": "error",
// 사용되지 않는 변수와 함수는 경고로 설정
"no-unused-vars": [
  "warn",
  {
    vars: "all",
    varsIgnorePattern: "^_",
    args: "after-used",
    argsIgnorePattern: "^_",
  },
],
```

npm install 하셔야합니다.